### PR TITLE
chore: replace print/subshell cd with p6_msg/p6_run_dir

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -59,7 +59,7 @@ p6df::modules::gws::skills::init() {
 ######################################################################
 p6df::modules::gws::langs() {
 
-  (cd "$P6_DFZ_SRC_DIR/googleworkspace/cli" && cargo build --release)
+  p6_run_dir "$P6_DFZ_SRC_DIR/googleworkspace/cli" cargo build --release
 
   p6_return_void
 }

--- a/lib/workspace.sh
+++ b/lib/workspace.sh
@@ -19,11 +19,11 @@ p6df::modules::gws::delegation::setup() {
   gws auth setup
   gws auth login
 
-  print ""
-  print "Account '${delegated_email}' ready. Use gws directly:"
-  print "  gws gmail users messages list --params '{\"userId\": \"me\"}'"
-  print "  gws drive files list"
-  print "  gws calendar events list --params '{\"calendarId\": \"primary\"}'"
+  p6_echo ""
+  p6_msg "Account '${delegated_email}' ready. Use gws directly:"
+  p6_msg "  gws gmail users messages list --params '{\"userId\": \"me\"}'"
+  p6_msg "  gws drive files list"
+  p6_msg "  gws calendar events list --params '{\"calendarId\": \"primary\"}'"
 
   p6_return_void
 }


### PR DESCRIPTION
Replace print with p6_echo/p6_msg and subshell cd with p6_run_dir in workspace.sh and init.zsh