### PR TITLE
fix(profile): simplify profile::mod return signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,15 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::gws::deps()`
 - `p6df::modules::gws::langs()`
-- `p6df::modules::gws::path::init()`
-- `p6df::modules::gws::skills::init()`
-- `words gws $GOOGLE_APPLICATION_CREDENTIALS = p6df::modules::gws::profile::mod()`
+- `p6df::modules::gws::path::init(_module, _dir)`
+  - Args:
+    - _module
+    - _dir
+- `p6df::modules::gws::skills::init(_module, _dir)`
+  - Args:
+    - _module
+    - _dir
+- `words gws = p6df::modules::gws::profile::mod()`
 
 #### p6df-gws/lib
 

--- a/init.zsh
+++ b/init.zsh
@@ -16,7 +16,11 @@ p6df::modules::gws::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::gws::path::init()
+# Function: p6df::modules::gws::path::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #  Environment:	 P6_DFZ_SRC_DIR
 #>
@@ -48,10 +52,10 @@ p6df::modules::gws::langs() {
 ######################################################################
 #<
 #
-# Function: words gws $GOOGLE_APPLICATION_CREDENTIALS = p6df::modules::gws::profile::mod()
+# Function: words gws = p6df::modules::gws::profile::mod()
 #
 #  Returns:
-#	words - gws $GOOGLE_APPLICATION_CREDENTIALS
+#	words - gws
 #
 #  Environment:	 GOOGLE_APPLICATION_CREDENTIALS
 #>


### PR DESCRIPTION
**What:** Remove env var from `profile::mod` return signature, returning only the module name word.

**Why:** Aligns with the updated `p6_return_words` convention where env vars are documented via the Environment section rather than encoded in the return value.

**Test plan:** Manual shell reload verification; no functional behavior change.

**Dependencies:** none